### PR TITLE
Use decompress library instead of unzip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: node_js
 node_js:
   - "4.1"
+branches:
+  only:
+    - master
+cache:
+  directories:
+    - node_modules
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: node_js
+
 node_js:
   - "4.1"
+
 branches:
   only:
     - master
+
 cache:
   directories:
     - node_modules
+
 notifications:
   email:
     on_success: never

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,10 @@ build: off
 
 skip_tags: true
 
+branches:
+  only:
+    - master
+
 environment:
   nodejs_version: "4.2.1"
 

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "author": "Kevin Sawicki",
   "license": "MIT",
   "dependencies": {
+    "decompress": "^3.0.0",
     "mkdirp": "^0.5.1",
-    "request": "^2.65.0",
-    "unzip": "^0.1.11"
+    "request": "^2.65.0"
   },
   "devDependencies": {
     "mocha": "^2.3.3",


### PR DESCRIPTION
Seeing `Download failed: invalid distance too far back` errors with the 0.37.x Chromedriver download.

Possibly related to https://github.com/EvanOxfeld/node-unzip/issues/60 to switching to a different unzip module.